### PR TITLE
Fix message error on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ subscription =
 message = %{title: "Notification Title", body: "lorem ipsum etc"}
 
 # generate request details
-%WebPushEx.Request{} = request = WebPushEx.request(subscription, :json.encode(message))
+%WebPushEx.Request{} = request = WebPushEx.request(subscription, :json.encode(message) |> to_string())
 
 request.endpoint
 # => "https://push.example.com/123"


### PR DESCRIPTION
I encountered an error while using the code example in the README.

```
** (ArgumentError) construction of binary failed: segment 1 of type 'binary': expected a binary but got: [~c"{", [[34, "title", 34], 58, 34, "teste", 34], [[44, [34, "body", 34], 58, 34, "", 34]], ~c"}"]
    (web_push_ex 0.1.0) lib/web_push.ex:145: WebPushEx.encrypt_payload/3
    (web_push_ex 0.1.0) lib/web_push.ex:27: WebPushEx.request/3
```

Added `to_string()` because `:json.encode(message)` isn't the same as `Jason.encode!(message)`, since one generates a list, the other a binary. 

Feel free to change to another example than the one I recommend.

