### PR TITLE
Fix missing :p256dh atom

### DIFF
--- a/lib/web_push/subscription.ex
+++ b/lib/web_push/subscription.ex
@@ -37,6 +37,9 @@ defmodule WebPushEx.Subscription do
 
         key in [:p256dh, :auth, :keys] ->
           value
+
+        true ->
+          value
       end
 
     [{key, value} | acc]

--- a/lib/web_push/subscription.ex
+++ b/lib/web_push/subscription.ex
@@ -31,10 +31,12 @@ defmodule WebPushEx.Subscription do
     key = String.to_existing_atom(key)
 
     value =
-      if key == :endpoint and is_binary(value) do
-        URI.parse(value)
-      else
-        value
+      cond do
+        key == :endpoint and is_binary(value) ->
+          URI.parse(value)
+
+        key in [:p256dh, :auth, :keys] ->
+          value
       end
 
     [{key, value} | acc]


### PR DESCRIPTION
`String.to_existing_atom(key)` will give an error because `:p256dh` atom doesn't exist. I think in your application, you have this atom, so it works when you use this dependency. 

I believe that `:auth` is common, but to not depend on other dependencies, I've added it as well. 

Feel free to modify to improve this version, not sure which alternative we can have to have an atom here that is useful for this to use and `to_existing_atom` to not give an error.